### PR TITLE
Fixed file_manager changing directories after adding a file

### DIFF
--- a/gs_manager/routes/file_manager.py
+++ b/gs_manager/routes/file_manager.py
@@ -26,15 +26,24 @@ def prefix_removal(text, prefixes):
 @fm.route('/file_manager/upload', methods=['GET', 'POST'])
 def upload():
     if request.method == 'POST':
-        f = request.files['file']
-        cwd = os.getcwd()
-        file_path = os.path.join(cwd, f.filename)
+        
+        fname = request.files['file']
+
+        cwd = request.form.get('cwd', os.getcwd())
+        
+        shared_prefix = os.path.commonprefix([cwd, PATH_STORAGE])
+
+        # The following command protects against deleting files outside of the storage.
+        if shared_prefix != PATH_STORAGE:
+            cwd = PATH_STORAGE
+
+        file_path = os.path.join(cwd, fname.filename)
 
         # If the file already exists then delete it first
         if os.path.exists(file_path):
             os.remove(file_path)
 
-        f.save(file_path)
+        fname.save(file_path)
         return redirect('/file_manager')
         # return render_template("file_manager/index.html")
 

--- a/gs_manager/templates/file_manager/index.html
+++ b/gs_manager/templates/file_manager/index.html
@@ -22,6 +22,7 @@
         <form action = "/file_manager/upload" method = "post" enctype="multipart/form-data">
           <label> Upload File: </label>
             <input type="file" name="file" />
+            <input type="hidden" id="cur_dir", name="dur_dir", value="{{ cwd }}">
             <input type = "submit" value="Upload">
         </form>
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where the file manager changes directories after adding a file by ensuring the current working directory is correctly set and validated.