### PR TITLE
Refactor vault URL logic into shared utility

### DIFF
--- a/gs_manager/routes/player_history.py
+++ b/gs_manager/routes/player_history.py
@@ -8,10 +8,11 @@ from sqlalchemy import (delete, insert)
 from ..extensions import db
 from ..models.server_nwn import PcActiveLog
 from sqlalchemy import null
-
+from ..services.character_service import CharacterService
+from flask import request
+from .vault_utils import get_vault_url
 
 ph = Blueprint('player_history', __name__)
-
 
 
 @ph.route('/player_history')
@@ -23,7 +24,17 @@ def index():
 @ph.route('/player_history/data')
 def data():
     query = PcActiveLog.query.filter(PcActiveLog.logoff_time.isnot(None))
-    data = {'data': [user.to_dict() for user in query]}
-    return data
-
-
+    data_list = []
+    
+    for user in query:
+        record = user.to_dict()
+        
+        # Generate vault URL if cd_key is available
+        if record.get('cd_key'):
+            record['vault_url'] = get_vault_url(record['server_name'], record['cd_key'])
+        else:
+            record['vault_url'] = None
+            
+        data_list.append(record)
+    
+    return {'data': data_list}

--- a/gs_manager/routes/players.py
+++ b/gs_manager/routes/players.py
@@ -6,14 +6,22 @@ from werkzeug.exceptions import abort
 from ..routes.auth import login_required
 from sqlalchemy import (delete, insert)
 from ..extensions import db
-from ..models.server_nwn import PcActiveLog
+from ..models.server_nwn import PcActiveLog, ServerConfigs, ServerVolumes, VolumesDirs
 from sqlalchemy import null
 from .. import socketio
 from flask_socketio import emit
 from flask import request
 from ..services.character_service import CharacterService
+import os
 
 pc = Blueprint('players', __name__)
+
+
+from ..services.character_service import CharacterService
+from .vault_utils import get_vault_url
+
+
+
 
 def get_active_players():
     query = (PcActiveLog.query.with_entities(
@@ -32,6 +40,9 @@ def get_active_players():
             record['server_name']
         )
         record['character_level'] = char_level if char_level is not None else 'N/A'
+
+        # Generate vault URL
+        record['vault_url'] = get_vault_url(record['server_name'], record['cd_key'])
 
         data.append(record)
     return data

--- a/gs_manager/routes/vault_utils.py
+++ b/gs_manager/routes/vault_utils.py
@@ -1,0 +1,46 @@
+from flask import url_for
+from ..models.server_nwn import ServerConfigs, ServerVolumes, VolumesDirs
+from ..services.character_service import CharacterService
+import os
+
+
+def get_vault_url(server_name, cd_key):
+    """
+    Generate a URL to view a character's vault folder in the volume manager.
+    
+    Args:
+        server_name (str): Name of the server
+        cd_key (str): Character's CD key
+    
+    Returns:
+        str: URL to the volume editor page, or None if not found
+    """
+    servervault_path = CharacterService.get_servervault_path(server_name)
+    if not servervault_path:
+        return None
+    
+    try:
+        server_config = ServerConfigs.query.filter_by(server_name=server_name).first()
+        if not server_config:
+            return None
+            
+        server_volumes = ServerVolumes.query.filter_by(server_configs_id=server_config.id).all()
+        if not server_volumes:
+            return None
+            
+        volume_ids = [sv.volumes_info_id for sv in server_volumes]
+        servervault_mount = VolumesDirs.query.filter(
+            VolumesDirs.volumes_info_id.in_(volume_ids),
+            VolumesDirs.dir_mount_loc == '/nwn/home/servervault',
+            VolumesDirs.dir_src_loc == servervault_path
+        ).first()
+        
+        if not servervault_mount:
+            return None
+            
+        full_path = os.path.join(servervault_path, cd_key)
+        return url_for('volume_manager.edit', id=servervault_mount.volumes_info_id, path=full_path)
+        
+    except Exception as e:
+        print(f"Error generating vault URL: {e}")
+        return None

--- a/gs_manager/templates/player_history/index.html
+++ b/gs_manager/templates/player_history/index.html
@@ -22,6 +22,7 @@
       <tr>
         <th>Player Name</th>
         <th>Character Name</th>
+        <th>Vault</th>
         <th>Server Name</th>
         <th>Logged on</th>
         <th>Logged off</th>
@@ -82,6 +83,17 @@
       columns: [
         {data: 'player_name', orderable: true, searchable: true},
         {data: 'character_name', orderable: true, searchable: true},
+        {
+          data: 'vault_url',
+          orderable: true,
+          searchable: false,
+          render: function(data, type, row) {
+            if (data) {
+              return `<a href="${data}" class="btn btn-sm btn-info" target="_blank">View Vault</a>`;
+            }
+            return '<span class="text-muted">-</span>';
+          }
+        },
         {data: 'server_name', orderable: true, searchable: true},
         {data: 'logon_time', orderable: true, searchable: true},
         {data: 'logoff_time', orderable: true, searchable: true}
@@ -94,13 +106,13 @@
                 initCollapsed: true,   
                 show: true,
             },
-            targets: [0, 2]
+            targets: [0, 3]
         },
         {
             searchPanes:{
                 show: false,
             },
-            targets: [1,3,4]
+            targets: [1,2,4,5]
         },
   
       ],

--- a/gs_manager/templates/players/index.html
+++ b/gs_manager/templates/players/index.html
@@ -10,6 +10,7 @@
             <th>ID</th>
             <th>Character Name</th>
             <th>Player Name</th>
+            <th>Vault</th>
             <th>Level</th>
             <th>Server Name</th>
             <th>Log On Time</th>
@@ -35,6 +36,15 @@
         { data: "id"},
         { data: "player_name"},
         { data: "character_name"},
+        {
+          data: "vault_url",
+          render: function(data, type, row) {
+            if (data) {
+              return `<a href="${data}" class="btn btn-sm btn-info" target="_blank">View Vault</a>`;
+            }
+            return '<span class="text-muted">-</span>';
+          }
+        },
         { data: "character_level", className: "dt-center"},
         { data: "server_name"},
         { data: "logon_time"},


### PR DESCRIPTION
- Create `vault_utils.py` with centralized `get_vault_url()` function
- Update `players.py` to use shared `get_vault_url()` instead of local `_get_vault_url()`
- Update `player_history.py` to use shared `get_vault_url()` instead of local `_get_vault_url()`
- Eliminate duplicate code while preserving functionality

## Summary by Sourcery

Centralize vault URL generation and expose vault links for active players and player history views.

New Features:
- Add a shared get_vault_url() helper to generate character vault URLs based on server configuration and CD key.
- Expose vault_url data in the players and player history APIs and render a Vault column with links to the volume manager in the corresponding tables.

Enhancements:
- Refactor existing vault URL logic out of route handlers into a reusable utility module to eliminate duplication.